### PR TITLE
[Fix] Timezone now set in config file

### DIFF
--- a/src/www/httpd/cgi-bin/set_configs.sh
+++ b/src/www/httpd/cgi-bin/set_configs.sh
@@ -46,9 +46,10 @@ for ROW in $ROWS; do
             hostname $VALUE
             echo "$VALUE" > $YI_HACK_PREFIX/etc/hostname
         fi
-    elif [ "$KEY" == "TIMEZONE" ] ; then
-        echo $VALUE > $YI_HACK_PREFIX/etc/TZ
     else
+        if [ "$KEY" == "TIMEZONE" ] ; then
+            echo $VALUE > $YI_HACK_PREFIX/etc/TZ
+        fi
         VALUE=$(echo "$VALUE" | sedencode)
         sed -i "s/^\(${KEY}\s*=\s*\).*$/\1${VALUE}/" $CONF_FILE
     fi


### PR DESCRIPTION
This fixes issue with timezone not being set (tested on Yi Dome 1080p).

Behaviour of setting TZ file has been left, as no harm leaving this in,
and possibly required for other models I was unable to test.

Resolves #22