### PR TITLE
[Fix] Stop active motion event when camera turned off

### DIFF
--- a/src/www/httpd/cgi-bin/camera_settings.sh
+++ b/src/www/httpd/cgi-bin/camera_settings.sh
@@ -21,6 +21,8 @@ do
     if [ "$CONF" == "switch_on" ] ; then
         if [ "$VAL" == "no" ] ; then
             ipc_cmd -t off
+            sleep 1
+            ipc_cmd -T  # Stop current motion detection event
         else
             ipc_cmd -t on
         fi


### PR DESCRIPTION
Currently the active motion detection event isn't stopped when turning
the camera to **off** state. This has knock on effect that future motion
event starts (when camera back in a **on** state) are missed by MQTT
subscribers, as it appears state of the topic hasn't changed.