### PR TITLE
[Fix] Enabled periodic update of snapshot on PTZ page.

### DIFF
--- a/src/www/httpd/htdocs/js/modules/ptz.js
+++ b/src/www/httpd/htdocs/js/modules/ptz.js
@@ -4,6 +4,22 @@ APP.ptz = (function ($) {
 
     function init() {
         registerEventHandler();
+        snapshotTimer();
+    }
+
+    function snapshotTimer() {
+        interval = 1000;
+        lastUpdate = Date.now();
+        function updateImage() {
+            jQuery.get('cgi-bin/snapshot.sh?res=low&base64=yes', function(data) {
+                image = document.getElementById('imgSnap');
+                image.src = 'data:image/png;base64,' + data;
+                this_interval = Math.max(interval - (Date.now() - lastUpdate), 0);
+                lastUpdate = Date.now();
+                setTimeout(updateImage, this_interval);
+            })
+        }
+        setTimeout(updateImage);
     }
 
     function registerEventHandler() {


### PR DESCRIPTION
Taking inspiration from [Allwinner PTZ page code][1], this code
repeatedly calls snapshot.

However, I found issues with snapshot being called too fast on my camera
so used a timer to ensure that camera only polled at fastest once per
second, or immediately after last snapshot is if the snapshot took more
than one second to return.

Resolves #11

[1]: https://github.com/roleoroleo/yi-hack-Allwinner/blob/9aab7bf60f522a50b65891c6ae67b65a49be645d/src/www/httpd/htdocs/js/modules/ptz.js#L61-L71