### PR TITLE
[Fix] No longer add extra "s" to start of config options

### DIFF
--- a/src/www/httpd/cgi-bin/set_configs.sh
+++ b/src/www/httpd/cgi-bin/set_configs.sh
@@ -51,7 +51,7 @@ for ROW in $ROWS; do
             echo $VALUE > $YI_HACK_PREFIX/etc/TZ
         fi
         VALUE=$(echo "$VALUE" | sedencode)
-        sed -i "s/^\(${KEY}\s*=\s*\).*$/\1${VALUE}/" $CONF_FILE
+        sed -i "s/^\(${KEY}[[:blank:]]*=[[:blank:]]*\).*$/\1${VALUE}/" $CONF_FILE
     fi
     
 done


### PR DESCRIPTION
This was caused by `\s` not being supported for matching whitespace, instead matching a literal "s".

This has been replaced by `[[:blank:]]` which will match spaces and tabs.

Fixes #19