### PR TITLE
Use ❤ as delimiter in set_configs.sh row iterator

### DIFF
--- a/src/www/httpd/cgi-bin/set_configs.sh
+++ b/src/www/httpd/cgi-bin/set_configs.sh
@@ -28,7 +28,8 @@ else
 fi
 
 read -r POST_DATA
-ROWS=$(echo "$POST_DATA" | jq -r '. | keys[] as $k | "\($k)=\(.[$k])"')
+ROWS=$(echo "$POST_DATA" | jq -r '. | keys[] as $k | "\($k)=\(.[$k])❤"')
+IFS='❤'
 for ROW in $ROWS; do
     KEY=$(echo $ROW | cut -d'=' -f1)
     VALUE=$(echo $ROW | cut -d'=' -f2)
@@ -55,6 +56,7 @@ for ROW in $ROWS; do
     fi
     
 done
+unset IFS
 
 # Yeah, it's pretty ugly.
 


### PR DESCRIPTION
This allows values with spaces (eg. crontab definitions). Fixes #112 