### PR TITLE
Use low resolution for motion snapshot

### DIFF
--- a/src/mqtt/dir.patch
+++ b/src/mqtt/dir.patch
@@ -9,7 +9,7 @@ diff -Naur mqttv4.ori/include/mqttv4.h mqttv4/include/mqttv4.h
 +#define MQTTV4_CONF_FILE    "/tmp/sd/yi-hack-v5/etc/mqttv4.conf"
  
 -#define MQTTV4_SNAPSHOT     "export MOD=$(cat /home/yi-hack/model_suffix); /home/yi-hack/bin/imggrabber -m $MOD -r high -w"
-+#define MQTTV4_SNAPSHOT     "export MOD=$(cat /home/app/.camver); /tmp/sd/yi-hack-v5/bin/imggrabber -m $MOD -r high -w"
++#define MQTTV4_SNAPSHOT     "export MOD=$(cat /home/app/.camver); /tmp/sd/yi-hack-v5/bin/imggrabber -m $MOD -r low -w"
  
  typedef struct
  {


### PR DESCRIPTION
Reduce motion snapshot latency (~4s for low v ~15s for high on my outdoor 1080p)
For motion snapshots I propose reduced response time is preferable to the slightly increased image quality.