### PR TITLE
Use hostname to expose Onvif camera

### DIFF
--- a/src/static/static/home/yi-hack-v5/script/system.sh
+++ b/src/static/static/home/yi-hack-v5/script/system.sh
@@ -429,7 +429,7 @@ if [[ $(get_config ONVIF) == "yes" ]] ; then
     onvif_notify_server --conf_file $ONVIF_SRVD_CONF
 
     if [[ $(get_config ONVIF_WSDD) == "yes" ]] ; then
-        wsd_simple_server --pid_file /var/run/wsd_simple_server.pid --if_name $ONVIF_NETIF --xaddr "http://%s$D_HTTPD_PORT/onvif/device_service" -m yi_hack -n Yi
+        wsd_simple_server --pid_file /var/run/wsd_simple_server.pid --if_name $ONVIF_NETIF --xaddr "http://%s$D_HTTPD_PORT/onvif/device_service" -m `hostname` -n Yi
     fi
 fi
 

--- a/src/www/httpd/cgi-bin/service.sh
+++ b/src/www/httpd/cgi-bin/service.sh
@@ -201,7 +201,7 @@ stop_onvif()
 
 start_wsdd()
 {
-    wsd_simple_server --pid_file /var/run/wsd_simple_server.pid --if_name $ONVIF_NETIF --xaddr "http://%s$D_HTTPD_PORT/onvif/device_service" -m yi_hack -n Yi
+    wsd_simple_server --pid_file /var/run/wsd_simple_server.pid --if_name $ONVIF_NETIF --xaddr "http://%s$D_HTTPD_PORT/onvif/device_service" -m `hostname` -n Yi
 }
 
 stop_wsdd()


### PR DESCRIPTION
Hello,

I have both camera that are exposed with the same name.
I propose to expose the hostname of the camera instead.